### PR TITLE
bump resolver

### DIFF
--- a/src/Network/AMQP/Worker/Connection.hs
+++ b/src/Network/AMQP/Worker/Connection.hs
@@ -54,7 +54,7 @@ connect opts = do
       chan <- catch (AMQP.openChannel conn) (createEx cvar)
       return chan
 
-    createEx cvar (ConnectionClosedException _) = do
+    createEx cvar (ConnectionClosedException _ _) = do
       reopenConnection cvar
       create cvar
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.9
+resolver: lts-11.16
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Since last versions of Network.AMQP changed ConnectionClosedException signature to take two arguments we need to adapt the code