### PR TITLE
package.yaml: rename 'example' binary to 'amqp-worker-example'

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,7 @@ library:
   source-dirs: src
 
 executables:
-  example:
+  amqp-worker-example:
     main:                Example.hs
     source-dirs:         test
     ghc-options:


### PR DESCRIPTION
'example' is an ambiguous executable name. For example 'pretty-terminal'
also installs 'example' binary causing collisions when installed
as a system package.

Let's rename the binary to be less ambiguous.